### PR TITLE
Fix NullPointerException with Multiverse-Core

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,6 +4,7 @@ version: ${project.version}
 author: segu23
 api-version: 1.13
 website: https://kayteam.org
+softdepend: [Multiverse-Core]
 commands:
   addchunk:
     description: AddChunk


### PR DESCRIPTION
Added "softdepend : [Multiverse-Core]" to the plugin.yml in order to avoid that the plugin generates a NullPointerException because Multiverse-Core has not loaded the worlds yet. The general role of the "softdepend" parameter is to ask the server to load the plugin after a certain list of plugins (if they are present).

Error log before fix :
```
[10:48:18] [Server thread/ERROR]: Error occurred while enabling ChunkLoader v3.0.1 (Is it up to date?)
java.lang.NullPointerException: null
	at java.util.Objects.requireNonNull(Objects.java:208) ~[?:?]
	at org.kayteam.chunkloader.main.ChunkManager.unformatChunk(ChunkManager.java:152) ~[ChunkLoader-3.0.1 (1).jar:?]
	at org.kayteam.chunkloader.main.ChunkManager.unformatChunk(ChunkManager.java:156) ~[ChunkLoader-3.0.1 (1).jar:?]
	at org.kayteam.chunkloader.main.ChunkManager.loadChunkList(ChunkManager.java:126) ~[ChunkLoader-3.0.1 (1).jar:?]
	at org.kayteam.chunkloader.main.ChunkManager.enableChunkLoad(ChunkManager.java:74) ~[ChunkLoader-3.0.1 (1).jar:?]
	at org.kayteam.chunkloader.main.ChunkLoader.loadAll(ChunkLoader.java:102) ~[ChunkLoader-3.0.1 (1).jar:?]
	at org.kayteam.chunkloader.main.ChunkLoader.onEnable(ChunkLoader.java:41) ~[ChunkLoader-3.0.1 (1).jar:?]
	at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:264) ~[paper-api-1.18.1-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.java.JavaPluginLoader.enablePlugin(JavaPluginLoader.java:370) ~[paper-api-1.18.1-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:501) ~[paper-api-1.18.1-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.craftbukkit.v1_18_R1.CraftServer.enablePlugin(CraftServer.java:562) ~[paper-1.18.1.jar:git-Paper-214]
	at org.bukkit.craftbukkit.v1_18_R1.CraftServer.enablePlugins(CraftServer.java:476) ~[paper-1.18.1.jar:git-Paper-214]
	at net.minecraft.server.MinecraftServer.loadWorld0(MinecraftServer.java:736) ~[paper-1.18.1.jar:git-Paper-214]
	at net.minecraft.server.MinecraftServer.loadLevel(MinecraftServer.java:503) ~[paper-1.18.1.jar:git-Paper-214]
	at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:313) ~[paper-1.18.1.jar:git-Paper-214]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1211) ~[paper-1.18.1.jar:git-Paper-214]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:317) ~[paper-1.18.1.jar:git-Paper-214]
	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```